### PR TITLE
#8 fixed the bb left hand nav issue; secured the target=_blank links

### DIFF
--- a/oeqCommon/src/main/java/org/apereo/openequella/integration/blackboard/common/content/ItemUtil.java
+++ b/oeqCommon/src/main/java/org/apereo/openequella/integration/blackboard/common/content/ItemUtil.java
@@ -57,7 +57,7 @@ public class ItemUtil {
     final String alt = (mimeType == null ? linkTitle : mimeType);
     final String html = MessageFormat.format(ItemUtil.HTML_TEMPLATE, serverUrl, getIcon(fileForIcon), alt,
         PathUtils.urlPath(BbUtil.getBlockRelativePath(), "ViewContent"), linkTitle,
-        (newWindow ? "target=\"_blank\"" : ""));
+        (newWindow ? "target=\"_blank\" rel=\"noopener noreferrer\"" : ""));
     if (!Strings.isNullOrEmpty(itemDescription)) {
       return html + "<div class=\"equella-description\" style=\"margin-top:10px\"><p>" + BbUtil.ent(itemDescription)
           + "</p></div>";

--- a/oeqPrimaryB2/src/main/java/org/apereo/openequella/integration/blackboard/buildingblock/Configuration.java
+++ b/oeqPrimaryB2/src/main/java/org/apereo/openequella/integration/blackboard/buildingblock/Configuration.java
@@ -74,7 +74,7 @@ public class Configuration {
     public static final String OAUTH_CLIENT_SECRET = "oauth.clientsecret";
     public static final String RESTRICTIONS = "restrictions";
     public static final String LOG_LEVEL = "loglevel";
-    public static final String NEWWINDOW = "newwindow";
+    public static final String NEW_WINDOW_OR_TAB = "newWindowOrTab";
 
     private static final String DEFAULT_SECRET = "";
     private static final String DEFAULT_RESTRICTION = "none";
@@ -100,7 +100,7 @@ public class Configuration {
     private String restriction;
     /* @Nullable */
     private String logLevel;
-    private boolean newWindow;
+    private boolean newWindowOrTab;
     /* @Nullable */
     private Set<String> mockPortalRoles;
 
@@ -157,11 +157,11 @@ public class Configuration {
         setOauthClientSecret(request.getParameter(OAUTH_CLIENT_SECRET));
         setRestriction(request.getParameter(RESTRICTIONS));
         setLogLevel(request.getParameter(LOG_LEVEL));
-        String newWindowParam = request.getParameter(NEWWINDOW);
+        String newWindowParam = request.getParameter(NEW_WINDOW_OR_TAB);
         if (newWindowParam == null || newWindowParam.equals("")) {
             newWindowParam = "false";
         }
-        setNewWindow(Boolean.parseBoolean(newWindowParam));
+        setNewWindowOrTab(Boolean.parseBoolean(newWindowParam));
         lastModified = Calendar.getInstance().getTime();
 
     }
@@ -200,7 +200,7 @@ public class Configuration {
             setMockPortalRoles(commaSplit(props.getProperty(MOCK_PORTAL_ROLES)));
             setRestriction(props.getProperty(RESTRICTIONS));
             setLogLevel(props.getProperty(LOG_LEVEL));
-            setNewWindow(Boolean.parseBoolean(props.getProperty(NEWWINDOW, "true")));
+            setNewWindowOrTab(Boolean.parseBoolean(props.getProperty(NEW_WINDOW_OR_TAB, "true")));
         } catch (Exception e) {
             BbLogger.instance().logError("Error loading configuration", e);
             throw new RuntimeException(e);
@@ -233,7 +233,7 @@ public class Configuration {
             props.setProperty(MOCK_PORTAL_ROLES, commaJoin(mockPortalRoles));
             props.setProperty(RESTRICTIONS, restriction);
             props.setProperty(LOG_LEVEL, logLevel);
-            props.setProperty(NEWWINDOW, Boolean.toString(newWindow));
+            props.setProperty(NEW_WINDOW_OR_TAB, Boolean.toString(newWindowOrTab));
             props.store(fos, null);
         } catch (Exception e) {
             BbLogger.instance().logError("Error saving configuration", e);
@@ -610,11 +610,11 @@ public class Configuration {
         BbLogger.instance().setLoggingLevel(LogLevel.valueOf(this.logLevel));
     }
 
-    public void setNewWindow(boolean newWindow) {
-        this.newWindow = newWindow;
+    public void setNewWindowOrTab(boolean newWindowOrTab) {
+        this.newWindowOrTab = newWindowOrTab;
     }
 
-    public boolean isNewWindow() {
-        return newWindow;
+    public boolean isNewWindowOrTab() {
+        return newWindowOrTab;
     }
 }

--- a/oeqPrimaryB2/src/main/java/org/apereo/openequella/integration/blackboard/buildingblock/data/WrappedContent.java
+++ b/oeqPrimaryB2/src/main/java/org/apereo/openequella/integration/blackboard/buildingblock/data/WrappedContent.java
@@ -99,11 +99,11 @@ public class WrappedContent implements Comparable<WrappedContent> {
 		getContent().setIsAvailable(available);
 	}
 
-	public void setNewWindow(boolean newWindow) {
+	public void setNewWindowOrTab(boolean newWindow) {
 		getContent().setLaunchInNewWindow(newWindow);
 	}
 
-	public boolean isNewWindow() {
+	public boolean isNewWindowOrTab() {
 		return getContent().getLaunchInNewWindow();
 	}
 
@@ -268,7 +268,7 @@ public class WrappedContent implements Comparable<WrappedContent> {
 	 */
 	public String getHtml(HttpServletRequest request, boolean bbEvaluateURLs) {
 		String html = ItemUtil.getHtml(Configuration.instance().getEquellaUrl(), getUrl(), getAttachmentName(),
-				getMimeType(), getTitle(), getDescription(), isNewWindow());
+				getMimeType(), getTitle(), getDescription(), isNewWindowOrTab());
 		if (bbEvaluateURLs) {
 			if (request != null && bbEvaluateURLs) {
 				final BbSession bbSession = BbSessionManagerServiceExFactory.getInstance().getSession(request);
@@ -432,7 +432,7 @@ public class WrappedContent implements Comparable<WrappedContent> {
 			final String endDateString = request.getParameter("date_end_datetime");
 			final String displayAfterString = request.getParameter("date_start_checkbox");
 			final String displayUntilString = request.getParameter("date_end_checkbox");
-			final String newWindowString = request.getParameter("newWindow");
+			final String newWindowString = request.getParameter("new_window_or_tab");
 			BbLogger.instance().logTrace("name=" + name);
 			BbLogger.instance().logTrace("description=" + description);
 			BbLogger.instance().logTrace("available=" + available);
@@ -453,7 +453,7 @@ public class WrappedContent implements Comparable<WrappedContent> {
 			setDescribed(described != null && described.equals("true"));
 			setDisplayAfter(displayAfterString != null && displayAfterString.equals("1"));
 			setDisplayUntil(displayUntilString != null && displayUntilString.equals("1"));
-			setNewWindow("true".equals(newWindowString));
+			setNewWindowOrTab("true".equals(newWindowString));
 			if (!Strings.isNullOrEmpty(startDateString)) {
 				final Calendar startDate = Calendar.getInstance();
 				startDate.setTime(DATE_FORMAT.parse(startDateString));

--- a/oeqPrimaryB2/src/main/java/org/apereo/openequella/integration/blackboard/buildingblock/servlet/ContentServlet.java
+++ b/oeqPrimaryB2/src/main/java/org/apereo/openequella/integration/blackboard/buildingblock/servlet/ContentServlet.java
@@ -423,7 +423,7 @@ public class ContentServlet extends HttpServlet {
 					}
 					final String mimeType = nodeValue(link, mimeTypeKey, null);
 					ContentUtil.instance().addContent(course.getCourse(), folderId, uuid, version, url, itemName, description,
-							attachmentUuid, attachmentName, mimeType, equellaUrl, configuration.isNewWindow());
+							attachmentUuid, attachmentName, mimeType, equellaUrl, configuration.isNewWindowOrTab());
 				}
 			}
 

--- a/oeqPrimaryB2/src/main/webapp/admin/config.jsp
+++ b/oeqPrimaryB2/src/main/webapp/admin/config.jsp
@@ -90,7 +90,7 @@ String secretId = configuration.getSecretId();
 String secret = configuration.getSecret();
 String restriction = configuration.getRestriction();
 String logLevel = configuration.getLogLevel();
-boolean newWindow = configuration.isNewWindow();
+boolean newWindowOrTab = configuration.isNewWindowOrTab();
 String loggingDetails = BbLogger.instance().getLoggingDetails();
 
 String title = "EQUELLA Server Configuration";
@@ -143,7 +143,7 @@ int number = 1;
 			</bbng:step>
 			
 			<bbng:step title="Options">
-        <bbng:dataElement label="Restrict selection of EQUELLA content">
+        <bbng:dataElement label="Restrict selection of openEQUELLA content">
           <bbng:selectElement name="<%=Configuration.RESTRICTIONS %>" >
             <bbng:selectOptionElement value="none" optionLabel="No restrictions" isSelected="<%=restriction.equals(\"none\") %>"/>
             <bbng:selectOptionElement value="itemonly" optionLabel="Items only" isSelected="<%=restriction.equals(\"itemonly\") %>"/>
@@ -163,8 +163,8 @@ int number = 1;
           </bbng:selectElement>
         </bbng:dataElement>
         
-        <bbng:dataElement label="Default new EQUELLA content to open in a new window">
-          <bbng:checkboxElement name="<%=Configuration.NEWWINDOW%>" value="true" isSelected="<%=newWindow%>" />
+        <bbng:dataElement label="Default new openEQUELLA content to open in a new window or tab">
+          <bbng:checkboxElement name="<%=Configuration.NEW_WINDOW_OR_TAB%>" value="true" isSelected="<%=newWindowOrTab%>" />
         </bbng:dataElement>
       </bbng:step>
       

--- a/oeqPrimaryB2/src/main/webapp/contribute/modify.jsp
+++ b/oeqPrimaryB2/src/main/webapp/contribute/modify.jsp
@@ -50,8 +50,8 @@
 				</bbng:dataElement>
 				
 				<bbng:dataElement label="Open in new window">
-					<bbng:radioElement name="newWindow" value="true"  isSelected="<%= content.isNewWindow()%>">Yes</bbng:radioElement>
-					<bbng:radioElement name="newWindow" value="false" isSelected="<%=!content.isNewWindow()%>">No</bbng:radioElement>
+					<bbng:radioElement name="new_window_or_tab" value="true"  isSelected="<%= content.isNewWindowOrTab()%>">Yes</bbng:radioElement>
+					<bbng:radioElement name="new_window_or_tab" value="false" isSelected="<%=!content.isNewWindowOrTab()%>">No</bbng:radioElement>
 				</bbng:dataElement>
 			
 				<bbng:dataElement label="Do you want to track number of views">

--- a/oeqPrimaryB2/src/main/webapp/portal/view.jsp
+++ b/oeqPrimaryB2/src/main/webapp/portal/view.jsp
@@ -58,16 +58,16 @@ catch (Exception e)
 
 <div id="equella_module">
 	<div class="section" id="search">
-		<div><a href="<%=link("home.do")%>" target="_blank">openEQUELLA Home</a></div>
-		<div><a href="<%=link("searching.do")%>" target="_blank">Search openEQUELLA</a></div>
-		<div><a href="<%=link("access/contribute.do")%>" target="_blank">Contribute to openEQUELLA</a></div>
+		<div><a href="<%=link("home.do")%>" target="_blank" rel="noopener noreferrer">openEQUELLA Home</a></div>
+		<div><a href="<%=link("searching.do")%>" target="_blank" rel="noopener noreferrer">Search openEQUELLA</a></div>
+		<div><a href="<%=link("access/contribute.do")%>" target="_blank" rel="noopener noreferrer">Contribute to openEQUELLA</a></div>
 	</div>
 	<hr>
 	<div class="section" id="tasks">
 		<n:notEmpty name="tasks">
 			<l:iterate id="task" name="tasks">
 		        <bean:define property="href" id="href" name="task" type="String"/>
-		        <div><a href="<%=href%>" target="_blank"><bean:write name="task" property="text"/></a></div>
+		        <div><a href="<%=href%>" target="_blank" rel="noopener noreferrer"><bean:write name="task" property="text"/></a></div>
 			</l:iterate>
 		</n:notEmpty>		
 		<n:empty name="tasks" >


### PR DESCRIPTION
The Bb Left hand nav issue was caused by the `newWindow` variable name in the forms / request object.  I switched all referenced to `newWindowOrTab` and the left hand nav issue no longer occurs.

I cleaned up some EQ > oE references.

In researching this issue, I found the setting `target` attribute of `<a>` elements can pose a security risk, so I included some measures to lessen that security risk.