### PR TITLE
#23 - override Bb API to set the lis_person_sourcedid

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-bbLearnVersion=3500.0.0
+bbLearnVersion=3700.0.0
 tomcatVersion=8.0.42
 gradleTomcatPluginVersion=2.5
 jstlVersion=1.2
@@ -6,4 +6,4 @@ jspApiVersion=2.3.3
 servletApiVersion=4.0.1
 junitVersion=4.12
 # All building blocks / web services are re-versioned when this changes.
-artifactVersion=2.0.3
+artifactVersion=2.0.4-SNAPSHOT-D

--- a/oeqPrimaryB2/src/main/java/org/apereo/openequella/integration/blackboard/buildingblock/lti/FixedBasicLtiLauncher.java
+++ b/oeqPrimaryB2/src/main/java/org/apereo/openequella/integration/blackboard/buildingblock/lti/FixedBasicLtiLauncher.java
@@ -116,19 +116,21 @@ public class FixedBasicLtiLauncher extends BasicLTILauncher {
 	@Override
 	public BasicLTILauncher addCurrentUserInformation(boolean includeRoles, boolean includeName, boolean includeEmail,
 			IdTypeToSend idTypeToSend) {
-		// add username
+		super.addCurrentUserInformation(includeRoles, includeName, includeEmail, idTypeToSend);
+
+		// Force an overwrite of the lis_person_sourcedid
 		Context ctx = ContextManagerFactory.getInstance().getContext();
 		User user = ctx.getUser();
-		addPostData("lis_person_sourcedid", user.getUserName());
-
-		return super.addCurrentUserInformation(includeRoles, includeName, includeEmail, idTypeToSend);
+		return addPostData("lis_person_sourcedid", user.getUserName());
 	}
 
 	@Override
 	public BasicLTILauncher addUserInformation(User user, CourseMembership membership, boolean includeRoles,
 			boolean includeName, boolean includeEmail, IdTypeToSend idTypeToSend) {
-		addPostData("lis_person_sourcedid", user.getUserName());
-		return super.addUserInformation(user, membership, includeRoles, includeName, includeEmail, idTypeToSend);
+		super.addUserInformation(user, membership, includeRoles, includeName, includeEmail, idTypeToSend);
+
+		// Force an overwrite of the lis_person_sourcedid
+		return addPostData("lis_person_sourcedid", user.getUserName());
 	}
 
 	public FixedBasicLtiLauncher addPostData(String key, /* @Nullable */String value) {


### PR DESCRIPTION
Fixes issue #23 .

I don't think the Bb API version bump was necessary, but it's good to stay current.