### PR TITLE
Chore/29 git release via travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,4 @@ deploy:
   file: oeqPrimaryB2/build/libs/*
   skip_cleanup: true
   on:
-    tags: true
+    branch: chore/29-git-release-via-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache:
 install: true
 
 script:
-  - ./gradlew :oeqPrimaryB2:clean :oeqPrimaryB2:buildB2
+  - ./gradlew :oeqPrimaryB2:clean :oeqPrimaryB2:buildB2 :oeqPrimaryWS:clean :oeqPrimaryWS:buildWS
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
@@ -21,7 +21,9 @@ deploy:
   api_key:
     secure: cpHkGCnmBxLuHnQ1qrGx2EQwVhw8kVHzdaiCrGTDQPcjIB1AWr1ID+UmDeEhZOOF6NYZakL579DvdDAiP7C9NwCT17mej0MZYwfy4yJl1BzZGSD73lq2zQtL0HeVtiaUSpP/GvsepATWSpM+E/hWW1kP+BTZgp/9fvzUYVV96S1tWDAq4EikRm5O5WOXInDni3oMXqxjZaGhs5YOvDD1cvNBpyuygqQI/YqJ9qXnTCIsXaYq0Wmk6rsQSEfagmkTBeu79WZairA6NVvb7iLWl1G/MqT+B01P1Zx1GtAm3arZUm38KIrJiQMzUPdAnKq88aYoQ+EW6l/NyWUkz40g6J2Hhc4V8AtBRUOXXx+TPO6GwPZ1DUu8n5R2/qm5L4OrH/k8n+QSeMZN2jLrMkK1gHQUXo8QF7N08JPD+BoZ0INeKXN2UdE9saVxFMvUDhvI/+BFMKA33/xqw2oWTMvtPvKDvmWJnTlS9veWc92fistNV8vHXDtC71PXVfIq6PYOsx7w1Yo5PEuRIkbJR2vaHFMiyqIEBJp1EM39OVj9+tUvslwQtJ5ZS5UXn3yLsrilVT3L1TuocU/fnU5SXuRGjEPNleLW7t2rT63pOXq37Qi7ZGoxUVFUFi2Iq6nzU2a4FhHSLDGa7bvMd4tgdN+zqVSxXPtaR5za9uSErNtp3v4=
   file_glob: true
-  file: oeqPrimaryB2/build/libs/*
+  file: 
+    - oeqPrimaryB2/build/libs/*
+    - oeqPrimaryWS/build/libs/*
   skip_cleanup: true
   on:
-    branch: chore/29-git-release-via-travis
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: java
+jdk:
+  - openjdk8
+
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+
+install: true
+
+script:
+  - ./gradlew :oeqPrimaryB2:clean :oeqPrimaryB2:buildB2
+
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
+deploy:
+  provider: releases
+  api_key:
+    secure: cpHkGCnmBxLuHnQ1qrGx2EQwVhw8kVHzdaiCrGTDQPcjIB1AWr1ID+UmDeEhZOOF6NYZakL579DvdDAiP7C9NwCT17mej0MZYwfy4yJl1BzZGSD73lq2zQtL0HeVtiaUSpP/GvsepATWSpM+E/hWW1kP+BTZgp/9fvzUYVV96S1tWDAq4EikRm5O5WOXInDni3oMXqxjZaGhs5YOvDD1cvNBpyuygqQI/YqJ9qXnTCIsXaYq0Wmk6rsQSEfagmkTBeu79WZairA6NVvb7iLWl1G/MqT+B01P1Zx1GtAm3arZUm38KIrJiQMzUPdAnKq88aYoQ+EW6l/NyWUkz40g6J2Hhc4V8AtBRUOXXx+TPO6GwPZ1DUu8n5R2/qm5L4OrH/k8n+QSeMZN2jLrMkK1gHQUXo8QF7N08JPD+BoZ0INeKXN2UdE9saVxFMvUDhvI/+BFMKA33/xqw2oWTMvtPvKDvmWJnTlS9veWc92fistNV8vHXDtC71PXVfIq6PYOsx7w1Yo5PEuRIkbJR2vaHFMiyqIEBJp1EM39OVj9+tUvslwQtJ5ZS5UXn3yLsrilVT3L1TuocU/fnU5SXuRGjEPNleLW7t2rT63pOXq37Qi7ZGoxUVFUFi2Iq6nzU2a4FhHSLDGa7bvMd4tgdN+zqVSxXPtaR5za9uSErNtp3v4=
+  file_glob: true
+  file: oeqPrimaryB2/build/libs/*
+  skip_cleanup: true
+  on:
+    tags: true

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,4 @@ jspApiVersion=2.3.3
 servletApiVersion=4.0.1
 junitVersion=4.12
 # All building blocks / web services are re-versioned when this changes.
-artifactVersion=2.0.5-SNAPSHOT
+artifactVersion=2.1.0-Alpha-20200205A


### PR DESCRIPTION
#29

While this functionality is being replaced with a pure LTI / REST flow between openEQUELLA and Blackboard, this will allow a cleaner release cycle for the building blocks / web service until they are sunset.

Since testing the travis fixes look to need to be in the default branch to be applied, this PR will be merged shortly, and is more of a paper trail.
